### PR TITLE
add cstdint header

### DIFF
--- a/oof.h
+++ b/oof.h
@@ -5,6 +5,7 @@
 #include <string>
 #include <variant>
 #include <vector>
+#include <cstdint>
 
 namespace oof
 {


### PR DESCRIPTION
failed to compile since uint8_t (struct color) is defined in cstdint header, which was not included